### PR TITLE
Use GitHub token provided by actions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Make GITHUB_ACCESS_TOKEN available
         run: echo $DOCKER_GITHUB_ACCESS_TOKEN > GITHUB_ACCESS_TOKEN
         env:
-          DOCKER_GITHUB_ACCESS_TOKEN: ${{ secrets.DOCKER_GITHUB_ACCESS_TOKEN }}
+          DOCKER_GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker Build
         run: DOCKER_BUILDKIT=1 docker build . -t docker.pkg.github.com/josephduffy/josephduffy.co.uk/website:$GITHUB_SHA --secret=id=GITHUB_ACCESS_TOKEN,src=./GITHUB_ACCESS_TOKEN


### PR DESCRIPTION
As-per https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/ secrets are now empty, so the `DOCKER_GITHUB_ACCESS_TOKEN` is now empty.